### PR TITLE
First envvar commit

### DIFF
--- a/source/envvar/envvar.go
+++ b/source/envvar/envvar.go
@@ -1,0 +1,111 @@
+package envvar
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/imdario/mergo"
+	"github.com/micro/go-config/source"
+)
+
+type envvar struct {
+	prefix string
+	opts   source.Options
+}
+
+func (e *envvar) Read() (*source.ChangeSet, error) {
+	var changes map[string]interface{}
+
+	for _, env := range os.Environ() {
+		if len(e.prefix) > 0 {
+			if !strings.HasPrefix(env, e.prefix) {
+				continue
+			}
+
+			env = strings.TrimPrefix(env, e.prefix)
+		}
+
+		env = strings.ToLower(env)
+		pair := strings.Split(env, "=")
+		value := pair[1]
+		keys := strings.Split(pair[0], "_")
+		reverse(keys)
+
+		tmp := make(map[string]interface{})
+		for i, k := range keys {
+			if i == 0 {
+				tmp[k] = value
+				continue
+			}
+
+			tmp = map[string]interface{}{k: tmp}
+		}
+
+		if err := mergo.Map(&changes, tmp); err != nil {
+			return nil, err
+		}
+	}
+
+	b, err := json.Marshal(changes)
+	if err != nil {
+		return nil, err
+	}
+
+	h := md5.New()
+	h.Write(b)
+	checksum := fmt.Sprintf("%x", h.Sum(nil))
+
+	return &source.ChangeSet{
+		Data:      b,
+		Checksum:  checksum,
+		Timestamp: time.Now(),
+		Source:    e.String(),
+	}, nil
+}
+
+func reverse(ss []string) {
+	for i := len(ss)/2 - 1; i >= 0; i-- {
+		opp := len(ss) - 1 - i
+		ss[i], ss[opp] = ss[opp], ss[i]
+	}
+}
+
+func (e *envvar) Watch() (source.Watcher, error) {
+	return newWatcher()
+}
+
+func (e *envvar) String() string {
+	return "envvar"
+}
+
+// NewSource returns a config source for parsing ENV variables.
+// Underscores are delimiters for nesting, and all keys are lowercased.
+//
+// Example:
+//      "DATABASE_SERVER_HOST=localhost" will convert to
+//
+//      {
+//          "database": {
+//              "server": {
+//                  "host": "localhost"
+//              }
+//          }
+//      }
+func NewSource(opts ...source.Option) source.Source {
+	var options source.Options
+	for _, o := range opts {
+		o(&options)
+	}
+
+	var prefix string
+	if options.Context != nil {
+		if p, ok := options.Context.Value(prefixKey{}).(string); ok {
+			prefix = p
+		}
+	}
+	return &envvar{prefix: prefix, opts: options}
+}

--- a/source/envvar/envvar_test.go
+++ b/source/envvar/envvar_test.go
@@ -1,0 +1,78 @@
+package envvar
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestEnvvar_Read(t *testing.T) {
+	expected := map[string]map[string]string{
+		"database": {
+			"host":     "localhost",
+			"password": "password",
+		},
+	}
+
+	os.Setenv("DATABASE_HOST", "localhost")
+	os.Setenv("DATABASE_PASSWORD", "password")
+
+	source := NewSource()
+	c, err := source.Read()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var actual map[string]interface{}
+	if err := json.Unmarshal(c.Data, &actual); err != nil {
+		t.Error(err)
+	}
+
+	actualDB := actual["database"].(map[string]interface{})
+
+	for k, v := range expected["database"] {
+		a := actualDB[k]
+
+		if a != v {
+			t.Errorf("expected %v got %v", v, a)
+		}
+	}
+}
+
+func TestEnvvar_PrefixIgnoresOtherEnvs(t *testing.T) {
+	os.Setenv("GOMICRO_DATABASE_HOST", "localhost")
+	os.Setenv("GOMICRO_DATABASE_PASSWORD", "password")
+	source := NewSource(WithPrefix("GOMICRO_"))
+
+	c, err := source.Read()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var actual map[string]interface{}
+	if err := json.Unmarshal(c.Data, &actual); err != nil {
+		t.Error(err)
+	}
+
+	if l := len(actual); l != 1 {
+		t.Errorf("expected 1 top key, got %v", l)
+	}
+}
+
+func TestEnvvar_WatchNextNoOpsUntilStop(t *testing.T) {
+	source := NewSource(WithPrefix("GOMICRO_"))
+	w, err := source.Watch()
+	if err != nil {
+		t.Error(err)
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		w.Stop()
+	}()
+
+	if _, err := w.Next(); err.Error() != "watcher stopped" {
+		t.Errorf("expected watcher stopped error, got %v", err)
+	}
+}

--- a/source/envvar/options.go
+++ b/source/envvar/options.go
@@ -1,0 +1,20 @@
+package envvar
+
+import (
+	"context"
+
+	"github.com/micro/go-config/source"
+)
+
+type prefixKey struct{}
+
+// WithPrefix sets the environment variable prefix to scope to.
+// This prefix will be removed from the actual config entries.
+func WithPrefix(p string) source.Option {
+	return func(o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, prefixKey{}, p)
+	}
+}

--- a/source/envvar/watcher.go
+++ b/source/envvar/watcher.go
@@ -1,0 +1,26 @@
+package envvar
+
+import (
+	"errors"
+
+	"github.com/micro/go-config/source"
+)
+
+type watcher struct {
+	exit chan struct{}
+}
+
+func (w *watcher) Next() (*source.ChangeSet, error) {
+	<-w.exit
+
+	return nil, errors.New("watcher stopped")
+}
+
+func (w *watcher) Stop() error {
+	close(w.exit)
+	return nil
+}
+
+func newWatcher() (source.Watcher, error) {
+	return &watcher{exit: make(chan struct{})}, nil
+}


### PR DESCRIPTION
Introducing a source for envvars. Prefix is supported for filtering down
the environment variables. Currently creates nested structures,
always lowercase, based on splitting at the _ of each env.