### PR TITLE
Adding microcli source

### DIFF
--- a/source/microcli/README.md
+++ b/source/microcli/README.md
@@ -1,0 +1,55 @@
+# microcli Source
+
+The microcli source reads config from parsed flags via a cli.Context.
+
+## Format
+
+We expect the use of the `micro/cli` package. Upper case flags will be lower cased. Dashes will be used as delimiters for nesting.
+
+### Example
+
+```go
+dbAddress := flag.String("database-address", "127.0.0.1", "the db address")
+dbPort := flag.Int("database-port", 3306, "the db port)
+```
+
+Becomes
+
+```json
+{
+    "database": {
+        "address": "127.0.0.1",
+        "port": 3306
+    }
+}
+```
+
+## New and Load Source
+
+Because a cli.Context is needed to retrieve the flags and their values, it is recommended to build your source from within a cli.Action.
+
+```go
+
+func main() {
+
+    // New Service
+    service := micro.NewService(
+        micro.Name("example"),
+        micro.Flags([]cli.Flag{
+            cli.StringFlag{Name: "database-name", Usage: "database name"},
+        }),
+    )
+
+    var clisrc source.Source
+    service.Init(
+        micro.Action(func(c *cli.Context) {
+            clisrc = microcli.NewSource(c)
+            // Alternatively, just setup your config right here
+        }),
+    )
+    
+    // ... Load and use that source ...
+    conf := config.NewConfig()
+    conf.Load(clisrc)
+}
+```

--- a/source/microcli/cli.go
+++ b/source/microcli/cli.go
@@ -1,0 +1,98 @@
+package microcli
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"github.com/imdario/mergo"
+	"github.com/micro/cli"
+	"github.com/micro/go-config/source"
+	"strings"
+	"time"
+)
+
+type clisrc struct {
+	opts source.Options
+	ctx  *cli.Context
+}
+
+func (c *clisrc) Read() (*source.ChangeSet, error) {
+	var changes map[string]interface{}
+
+	for _, name := range c.ctx.GlobalFlagNames() {
+		tmp := toEntry(name, c.ctx.GlobalGeneric(name))
+		mergo.Map(&changes, tmp) // need to sort error handling
+	}
+
+	for _, name := range c.ctx.FlagNames() {
+		tmp := toEntry(name, c.ctx.Generic(name))
+		mergo.Map(&changes, tmp) // need to sort error handling
+	}
+
+	b, err := json.Marshal(changes)
+	if err != nil {
+		return nil, err
+	}
+
+	h := md5.New()
+	h.Write(b)
+	checksum := fmt.Sprintf("%x", h.Sum(nil))
+
+	return &source.ChangeSet{
+		Data:      b,
+		Checksum:  checksum,
+		Timestamp: time.Now(),
+		Source:    c.String(),
+	}, nil
+}
+
+func toEntry(name string, v interface{}) map[string]interface{} {
+	n := strings.ToLower(name)
+	keys := strings.Split(n, "-")
+	reverse(keys)
+	tmp := make(map[string]interface{})
+	for i, k := range keys {
+		if i == 0 {
+			tmp[k] = v
+			continue
+		}
+
+		tmp = map[string]interface{}{k: tmp}
+	}
+	return tmp
+}
+
+func reverse(ss []string) {
+	for i := len(ss)/2 - 1; i >= 0; i-- {
+		opp := len(ss) - 1 - i
+		ss[i], ss[opp] = ss[opp], ss[i]
+	}
+}
+func (c *clisrc) Watch() (source.Watcher, error) {
+	return source.NewNoopWatcher()
+}
+
+func (c *clisrc) String() string {
+	return "microcli"
+}
+
+// NewSource returns a config source for integrating parsed flags from a micro/cli.Context.
+// Hyphens are delimiters for nesting, and all keys are lowercased.
+//
+// Example:
+//      cli.StringFlag{Name: "db-host"},
+//
+//
+//      {
+//          "database": {
+//              "host": "localhost"
+//          }
+//      }
+func NewSource(ctx *cli.Context, opts ...source.Option) source.Source {
+	var options source.Options
+	for _, o := range opts {
+		o(&options)
+	}
+
+	return &clisrc{opts: options, ctx: ctx}
+}

--- a/source/microcli/cli_test.go
+++ b/source/microcli/cli_test.go
@@ -1,0 +1,36 @@
+package microcli
+
+import (
+	"testing"
+	"github.com/micro/cli"
+	"github.com/micro/go-config/source"
+	"encoding/json"
+)
+
+func TestClisrc_Read(t *testing.T) {
+	var src source.Source
+	app := cli.NewApp()
+	app.Name = "testapp"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{Name: "db-host"},
+	}
+	app.Action = func(c *cli.Context) {
+		src = NewSource(c)
+	}
+	app.Run([]string{"run", "-db-host", "localhost"})
+
+	c, err := src.Read()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var actual map[string]interface{}
+	if err := json.Unmarshal(c.Data, &actual); err != nil {
+		t.Error(err)
+	}
+
+	actualDB := actual["db"].(map[string]interface{})
+	if actualDB["host"] != "localhost" {
+		t.Errorf("expected localhost, got %s", actualDB["name"])
+	}
+}


### PR DESCRIPTION
Same approach as flag and envvar, but specifically for micro/cli, which
requires the caller to provide a cli.Context for integrating the flags.