### PR TITLE
envvar source updates for micro and multi-prefix

### DIFF
--- a/source/envvar/README.md
+++ b/source/envvar/README.md
@@ -27,16 +27,52 @@ Becomes
 }
 ```
 
-### Namespace
+## Prefixes
 
-Env vars can be namespaced so we only have access to a subset
+Environment variables can be namespaced so we only have access to a subset. Two options are available:
 
 ```
-MICRO_DATABASE_ADDRESS=127.0.0.1
-MICRO_DATABASE_PORT=3306
+WithPrefix(p ...string)
+WithStrippedPrefix(p ...string)
 ```
 
-The prefix will be trimmed on access
+The former will preserve the prefix and make it a top level key in the config. The latter eliminates the prefix, reducing the nesting by one. 
+
+_Note: If any prefixes are provided, "MICRO" will automatically be included to support the micro tooling._
+
+#### Example:
+
+Given ENVs of:
+
+```
+APP_DATABASE_ADDRESS=127.0.0.1
+APP_DATABASE_PORT=3306
+VAULT_ADDR=vault:1337
+```
+
+and a source initialized as follows:
+
+```
+envvarsrc := envvar.NewSource(
+    envvar.WithPrefix("VAULT"),
+    envvar.WithStrippedPrefix("APP"),
+)
+```
+
+The resulting config will be:
+
+```
+{
+    "database": {
+        "address": "127.0.0.1",
+        "port": 3306
+    },
+    "vault": {
+        "addr": "vault:1337"
+    }
+}
+```
+
 
 ## New Source
 

--- a/source/envvar/options.go
+++ b/source/envvar/options.go
@@ -3,18 +3,47 @@ package envvar
 import (
 	"context"
 
+	"strings"
+
 	"github.com/micro/go-config/source"
 )
 
+type strippedPrefixKey struct{}
 type prefixKey struct{}
 
-// WithPrefix sets the environment variable prefix to scope to.
-// This prefix will be removed from the actual config entries.
-func WithPrefix(p string) source.Option {
+// WithStrippedPrefix sets the environment variable prefixes to scope to.
+// These prefixes will be removed from the actual config entries.
+func WithStrippedPrefix(p ...string) source.Option {
 	return func(o *source.Options) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
-		o.Context = context.WithValue(o.Context, prefixKey{}, p)
+
+		o.Context = context.WithValue(o.Context, strippedPrefixKey{}, appendUnderscore(p))
 	}
+}
+
+// WithPrefix sets the environment variable prefixes to scope to.
+// These prefixes will not be removed. Each prefix will be considered a top level config entry.
+func WithPrefix(p ...string) source.Option {
+	return func(o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, prefixKey{}, appendUnderscore(p))
+	}
+}
+
+func appendUnderscore(prefixes []string) []string {
+	var result []string
+	for _, p := range prefixes {
+		if !strings.HasSuffix(p, "_") {
+			result = append(result, p+"_")
+			continue
+		}
+
+		result = append(result, p)
+	}
+
+	return result
 }


### PR DESCRIPTION
This PR addresses the slack discussion of introducing WithPrefix and
WithStrippedPrefix. Multiple prefixes of either kind are now supported,
and MICRO is automatically included as a prefix by default.