### PR TITLE
fix: fsnotify import path

### DIFF
--- a/source/file/watcher.go
+++ b/source/file/watcher.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/micro/go-config/source"
-	"gopkg.in/fsnotify.v1"
+	"github.com/fsnotify/fsnotify"
 )
 
 type watcher struct {


### PR DESCRIPTION
`gopkg.in/fsnotify.v1` Git repo is empty now
replaces this with `github.com/fsnotify/fsnotify`