### PR TITLE
Introducing boolean to strip the prefix in the same style as envvars.

### DIFF
--- a/source/consul/README.md
+++ b/source/consul/README.md
@@ -31,6 +31,8 @@ consulSource := consul.NewSource(
 	consul.WithAddress("10.0.0.10:8500"),
 	// optionally specify prefix; defaults to /micro/config
 	consul.WithPrefix("/my/prefix"),
+  // optionally strip the provided prefix from the keys, defaults to false
+  consul.StripPrefix(true),
 )
 ```
 

--- a/source/consul/options.go
+++ b/source/consul/options.go
@@ -8,6 +8,7 @@ import (
 
 type addressKey struct{}
 type prefixKey struct{}
+type stripPrefixKey struct{}
 
 // WithAddress sets the consul address
 func WithAddress(a string) source.Option {
@@ -26,5 +27,16 @@ func WithPrefix(p string) source.Option {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, prefixKey{}, p)
+	}
+}
+
+// StripPrefix indicates whether to remove the prefix from config entries, or leave it in place.
+func StripPrefix(strip bool) source.Option {
+	return func(o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+
+		o.Context = context.WithValue(o.Context, stripPrefixKey{}, strip)
 	}
 }

--- a/source/consul/util.go
+++ b/source/consul/util.go
@@ -7,12 +7,14 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-func makeMap(kv api.KVPairs) map[string]interface{} {
+func makeMap(kv api.KVPairs, stripPrefix string) map[string]interface{} {
 	data := make(map[string]interface{})
 
 	for _, v := range kv {
+		// remove prefix if non empty, and ensure leading / is removed as well
+		vkey := strings.TrimPrefix(strings.TrimPrefix(v.Key, stripPrefix), "/")
 		// split on prefix
-		keys := strings.Split(v.Key, "/")
+		keys := strings.Split(vkey, "/")
 
 		var vals interface{}
 		json.Unmarshal(v.Value, &vals)

--- a/source/consul/watcher.go
+++ b/source/consul/watcher.go
@@ -12,18 +12,20 @@ import (
 )
 
 type watcher struct {
-	name string
+	name        string
+	stripPrefix string
 
 	wp   *watch.Plan
 	ch   chan *source.ChangeSet
 	exit chan bool
 }
 
-func newWatcher(key, addr, name string) (source.Watcher, error) {
+func newWatcher(key, addr, name string, stripPrefix string) (source.Watcher, error) {
 	w := &watcher{
-		name: name,
-		ch:   make(chan *source.ChangeSet),
-		exit: make(chan bool),
+		name:        name,
+		stripPrefix: stripPrefix,
+		ch:          make(chan *source.ChangeSet),
+		exit:        make(chan bool),
 	}
 
 	wp, err := watch.Parse(map[string]interface{}{"type": "keyprefix", "prefix": key})
@@ -52,7 +54,7 @@ func (w *watcher) handle(idx uint64, data interface{}) {
 		return
 	}
 
-	d := makeMap(kvs)
+	d := makeMap(kvs, w.stripPrefix)
 
 	b, err := json.Marshal(d)
 	if err != nil {


### PR DESCRIPTION
By allowing for a stripped consul prefix, all sources can potentially
merge at the same root. Example: GOMICRO_GEOSRV_DB_HOST from envvar and
geosrv/db/port from consul could use stripped prefixes to make "db" a
top level key with entries of "host" and "port".