### PR TITLE
Fixed watch bug in consul source.

### DIFF
--- a/source/consul/watcher.go
+++ b/source/consul/watcher.go
@@ -33,9 +33,12 @@ func newWatcher(key, addr, name string) (source.Watcher, error) {
 
 	wp.Handler = w.handle
 
-	if err := wp.Run(addr); err != nil {
-		return nil, err
-	}
+	// wp.Run is a blocking call and will prevent newWatcher from returning
+	go func() {
+		if err := wp.Run(addr); err != nil {
+			return
+		}
+	}()
 
 	w.wp = wp
 


### PR DESCRIPTION
watchplan.Run is a blocking call. Since it was being called inside of
the newWatcher method, this prevented the newWatcher method from
returning. Consul also immediately delivers a first change set to the
handler, which blocks indefinitely on sending the changeset, because
nothing can listen on the watcher channel until newWatcher completes.