### PR TITLE
issue #18: Replace mergo

### DIFF
--- a/issue18_test.go
+++ b/issue18_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/micro/go-config/source/envvar"
+	"github.com/micro/go-config/source/file"
+)
+
+func createFileForIssue18(t *testing.T, content string) *os.File {
+	data := []byte(content)
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("file.%d", time.Now().UnixNano()))
+	fh, err := os.Create(path)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = fh.Write(data)
+	if err != nil {
+		t.Error(err)
+	}
+
+	return fh
+}
+
+func TestIssue18(t *testing.T) {
+	fh := createFileForIssue18(t, `{
+  "amqp": {
+    "host": "rabbit.platform",
+    "port": 80
+  },
+  "handler": {
+    "exchange": "springCloudBus"
+  }
+}`)
+	path := fh.Name()
+	defer func() {
+		fh.Close()
+		os.Remove(path)
+	}()
+	os.Setenv("AMQP_HOST", "rabbit.testing.com")
+
+	conf := NewConfig()
+	conf.Load(
+		file.NewSource(
+			file.WithPath(path),
+		),
+		envvar.NewSource(),
+	)
+
+	actualHost := conf.Get("amqp", "host").String("backup")
+	if actualHost != "rabbit.testing.com" {
+		t.Fatalf("Expected %v but got %v",
+			"rabbit.testing.com",
+			actualHost)
+	}
+}

--- a/mapm/mapm.go
+++ b/mapm/mapm.go
@@ -1,0 +1,66 @@
+// Package mapm allows a basic merge of 2 map[string]interface{}
+package mapm
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Merge merges 2 maps and return the merge results.
+// Please note that trg map will be changed during merge
+func Merge(trg map[string]interface{}, src map[string]interface{}) (map[string]interface{}, error) {
+	// Create map if needed
+	if trg == nil && src != nil {
+		trg = make(map[string]interface{})
+	}
+
+	for k, v := range src {
+		item, present := trg[k]
+		// if not present, no merge
+		if !present {
+			trg[k] = v
+			continue
+		}
+
+		// They are different type, so ignore merge
+		if reflect.TypeOf(item) != reflect.TypeOf(v) {
+			continue
+		}
+
+		// Let's look deeper
+		switch reflect.TypeOf(v).Kind() {
+		// Append to slice
+		case reflect.Slice:
+			reflect.ValueOf(trg).SetMapIndex(
+				reflect.ValueOf(k),
+				reflect.AppendSlice(
+					reflect.ValueOf(item),
+					reflect.ValueOf(v)))
+
+			// Merge map
+		case reflect.Map:
+			itemMap, ok := item.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("could not convert item %v (%T) to map",
+					item,
+					item)
+			}
+			sourceMap, ok := v.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("could not convert item %v (%T) to map",
+					v,
+					v)
+			}
+			var err error
+			if trg[k], err = Merge(itemMap, sourceMap); err != nil {
+				return nil, fmt.Errorf("failed to merge key %v: %v",
+					k,
+					err)
+			}
+			// Replace
+		default:
+			trg[k] = v
+		}
+	}
+	return trg, nil
+}

--- a/mapm/mapm_test.go
+++ b/mapm/mapm_test.go
@@ -1,0 +1,85 @@
+package mapm
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testCase struct {
+	a        map[string]interface{}
+	b        map[string]interface{}
+	expected map[string]interface{}
+	error    bool
+}
+
+func TestMerge(t *testing.T) {
+	cases := []testCase{
+		// Simple case
+		{
+			a: map[string]interface{}{
+				"a": "b",
+			},
+			b: map[string]interface{}{
+				"a": "c",
+			},
+			expected: map[string]interface{}{
+				"a": "c",
+			},
+			error: false,
+		},
+		// Array
+		{
+			a: map[string]interface{}{
+				"a": []string{"1", "2", "3"},
+			},
+			b: map[string]interface{}{
+				"a": []string{"4", "5", "6"},
+			},
+			expected: map[string]interface{}{
+				"a": []string{"1", "2", "3", "4", "5", "6"},
+			},
+			error: false,
+		},
+		// Multi layer
+		{
+			a: map[string]interface{}{
+				"k1": "v1",
+				"k2": map[string]interface{}{
+					"k2.1": "v2",
+				},
+			},
+			b: map[string]interface{}{
+				"k1": "v1bis",
+				"k2": map[string]interface{}{
+					"k2.2": "v3",
+				},
+			},
+			expected: map[string]interface{}{
+				"k1": "v1bis",
+				"k2": map[string]interface{}{
+					"k2.1": "v2",
+					"k2.2": "v3",
+				},
+			},
+			error: false,
+		},
+	}
+
+	for idx, tc := range cases {
+		actual, err := Merge(tc.a, tc.b)
+		if tc.error && err == nil {
+			t.Errorf("expected failed merge but was successful for test case %d: %v",
+				idx,
+				tc)
+			continue
+		}
+		if !reflect.DeepEqual(tc.expected, actual) {
+			t.Errorf("expected %v but was %v for test case %d",
+				tc.expected,
+				tc.a,
+				idx)
+			continue
+		}
+	}
+
+}

--- a/reader/json/json.go
+++ b/reader/json/json.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/imdario/mergo"
 	"github.com/micro/go-config/reader"
 	"github.com/micro/go-config/source"
 	hash "github.com/mitchellh/hashstructure"
+	"github.com/pijalu/go-config/mapm"
 )
 
 type jsonReader struct{}
@@ -30,7 +30,8 @@ func (j *jsonReader) Parse(changes ...*source.ChangeSet) (*source.ChangeSet, err
 		if err := json.Unmarshal(m.Data, &data); err != nil {
 			return nil, err
 		}
-		if err := mergo.Map(&merged, data, mergo.WithOverride); err != nil {
+		var err error
+		if merged, err = mapm.Merge(merged, data); err != nil {
 			return nil, err
 		}
 	}

--- a/reader/json/json.go
+++ b/reader/json/json.go
@@ -30,7 +30,7 @@ func (j *jsonReader) Parse(changes ...*source.ChangeSet) (*source.ChangeSet, err
 		if err := json.Unmarshal(m.Data, &data); err != nil {
 			return nil, err
 		}
-		if err := mergo.MapWithOverwrite(&merged, data); err != nil {
+		if err := mergo.Map(&merged, data, mergo.WithOverride); err != nil {
 			return nil, err
 		}
 	}

--- a/source/envvar/envvar.go
+++ b/source/envvar/envvar.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/imdario/mergo"
 	"github.com/micro/go-config/source"
+	"github.com/pijalu/go-config/mapm"
 )
 
 var (
@@ -59,7 +59,8 @@ func (e *envvar) Read() (*source.ChangeSet, error) {
 			tmp = map[string]interface{}{k: tmp}
 		}
 
-		if err := mergo.Map(&changes, tmp); err != nil {
+		var err error
+		if changes, err = mapm.Merge(changes, tmp); err != nil {
 			return nil, err
 		}
 	}

--- a/source/flag/flag.go
+++ b/source/flag/flag.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/imdario/mergo"
-	"github.com/micro/go-config/source"
+	"log"
 	"strings"
 	"time"
+
+	"github.com/micro/go-config/source"
+	"github.com/pijalu/go-config/mapm"
 )
 
 type flagsrc struct {
@@ -37,7 +39,11 @@ func (fs *flagsrc) Read() (*source.ChangeSet, error) {
 			tmp = map[string]interface{}{k: tmp}
 		}
 
-		mergo.Map(&changes, tmp) // need to sort error handling
+		var err error
+		changes, err = mapm.Merge(changes, tmp) // need to sort error handling
+		if err != nil {
+			log.Printf("error during merge: %v", err)
+		}
 		return
 	})
 

--- a/source/microcli/cli_test.go
+++ b/source/microcli/cli_test.go
@@ -2,9 +2,10 @@ package microcli
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/micro/cli"
 	"github.com/micro/go-config/source"
-	"testing"
 )
 
 func TestClisrc_Read(t *testing.T) {
@@ -27,6 +28,10 @@ func TestClisrc_Read(t *testing.T) {
 	var actual map[string]interface{}
 	if err := json.Unmarshal(c.Data, &actual); err != nil {
 		t.Error(err)
+	}
+
+	if actual["db"] == nil {
+		t.Fatalf("actual does not contains expected keys: %v", actual["name"])
 	}
 
 	actualDB := actual["db"].(map[string]interface{})


### PR DESCRIPTION
Another take for a fix of issue 18: Remove mergo and uses a local/basic map merger.
Only required if Mergo does not merge the fix.

