### PR TITLE
Add Format field to ChangeSet

### DIFF
--- a/source/changeset.go
+++ b/source/changeset.go
@@ -1,0 +1,13 @@
+package source
+
+import (
+	"crypto/md5"
+	"fmt"
+)
+
+// Sum returns the md5 checksum of the ChangeSet data
+func (c *ChangeSet) Sum() string {
+	h := md5.New()
+	h.Write(c.Data)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/source/configmap/configmap.go
+++ b/source/configmap/configmap.go
@@ -14,7 +14,7 @@ import (
 type configmap struct {
 	opts       source.Options
 	client     *kubernetes.Clientset
-	cerr	error
+	cerr       error
 	name       string
 	namespace  string
 	configPath string
@@ -109,7 +109,7 @@ func NewSource(opts ...source.Option) source.Source {
 	client, err := getClient(configPath)
 
 	return &configmap{
-		cerr: err,
+		cerr:       err,
 		client:     client,
 		opts:       options,
 		name:       name,

--- a/source/configmap/configmap.go
+++ b/source/configmap/configmap.go
@@ -43,9 +43,10 @@ func (k *configmap) Read() (*source.ChangeSet, error) {
 	}
 
 	cs := &source.ChangeSet{
-		Format: "json",
-		Source: k.String(),
-		Data:   b,
+		Format:    "json",
+		Source:    k.String(),
+		Data:      b,
+		Timestamp: cmp.CreationTimestamp.Time,
 	}
 	cs.Checksum = cs.Sum()
 

--- a/source/configmap/configmap.go
+++ b/source/configmap/configmap.go
@@ -2,7 +2,6 @@
 package configmap
 
 import (
-	"crypto/md5"
 	"encoding/json"
 	"fmt"
 
@@ -43,16 +42,14 @@ func (k *configmap) Read() (*source.ChangeSet, error) {
 		return nil, fmt.Errorf("error reading source: %v", err)
 	}
 
-	h := md5.New()
-	h.Write(b)
-	checksum := fmt.Sprintf("%x", h.Sum(nil))
+	cs := &source.ChangeSet{
+		Format: "json",
+		Source: k.String(),
+		Data:   b,
+	}
+	cs.Checksum = cs.Sum()
 
-	return &source.ChangeSet{
-		Format:   "json",
-		Source:   k.String(),
-		Data:     b,
-		Checksum: checksum,
-	}, nil
+	return cs, nil
 }
 
 func (k *configmap) String() string {

--- a/source/configmap/configmap_test.go
+++ b/source/configmap/configmap_test.go
@@ -118,7 +118,7 @@ func TestMakeMap(t *testing.T) {
 }
 
 func TestConfigmap_Read(t *testing.T) {
-//	cfg := os.Getenv("HOME") + "/.kube/config"
+	//	cfg := os.Getenv("HOME") + "/.kube/config"
 	data := []byte(`{"config":{"host":"0.0.0.0","port":"1337"},"mongodb":{"host":"127.0.0.1","password":"password","port":"27017","user":"user"},"redis":{"url":"redis://127.0.0.1:6379/db01"}}`)
 
 	tt := []struct {
@@ -137,7 +137,7 @@ func TestConfigmap_Read(t *testing.T) {
 			source := NewSource(
 				WithName(tc.sname),
 				WithNamespace(tc.namespace),
-//				WithConfigPath(cfg),
+				//				WithConfigPath(cfg),
 			)
 
 			r, err := source.Read()
@@ -164,11 +164,11 @@ func TestConfigmap_String(t *testing.T) {
 }
 
 func TestNewSource(t *testing.T) {
-//	cfg := os.Getenv("HOME") + "/.kube/config"
+	//	cfg := os.Getenv("HOME") + "/.kube/config"
 	conf := config.NewConfig()
 
 	conf.Load(NewSource(
-//		WithConfigPath(cfg),
+	//		WithConfigPath(cfg),
 	))
 
 	if mongodbHost := conf.Get("mongodb", "host").String("localhost"); mongodbHost != "127.0.0.1" {

--- a/source/configmap/configmap_test.go
+++ b/source/configmap/configmap_test.go
@@ -118,7 +118,7 @@ func TestMakeMap(t *testing.T) {
 }
 
 func TestConfigmap_Read(t *testing.T) {
-	cfg := os.Getenv("HOME") + "/.kube/config"
+//	cfg := os.Getenv("HOME") + "/.kube/config"
 	data := []byte(`{"config":{"host":"0.0.0.0","port":"1337"},"mongodb":{"host":"127.0.0.1","password":"password","port":"27017","user":"user"},"redis":{"url":"redis://127.0.0.1:6379/db01"}}`)
 
 	tt := []struct {
@@ -137,12 +137,13 @@ func TestConfigmap_Read(t *testing.T) {
 			source := NewSource(
 				WithName(tc.sname),
 				WithNamespace(tc.namespace),
-				WithConfigPath(cfg),
+//				WithConfigPath(cfg),
 			)
 
 			r, err := source.Read()
 			if err != nil {
 				t.Errorf("not able to read the config values because: %v", err)
+				return
 			}
 
 			if string(r.Data) != string(data) {
@@ -163,11 +164,11 @@ func TestConfigmap_String(t *testing.T) {
 }
 
 func TestNewSource(t *testing.T) {
-	cfg := os.Getenv("HOME") + "/.kube/config"
+//	cfg := os.Getenv("HOME") + "/.kube/config"
 	conf := config.NewConfig()
 
 	conf.Load(NewSource(
-		WithConfigPath(cfg),
+//		WithConfigPath(cfg),
 	))
 
 	if mongodbHost := conf.Get("mongodb", "host").String("localhost"); mongodbHost != "127.0.0.1" {

--- a/source/configmap/watcher.go
+++ b/source/configmap/watcher.go
@@ -64,9 +64,10 @@ func (w *watcher) handle(oldCmp interface{}, newCmp interface{}) {
 	}
 
 	cs := &source.ChangeSet{
-		Format: "json",
-		Source: w.name,
-		Data:   b,
+		Format:    "json",
+		Source:    w.name,
+		Data:      b,
+		Timestamp: newCmp.(v12.ConfigMap).CreationTimestamp.Time,
 	}
 	cs.Checksum = cs.Sum()
 

--- a/source/configmap/watcher.go
+++ b/source/configmap/watcher.go
@@ -1,10 +1,8 @@
 package configmap
 
 import (
-	"crypto/md5"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/micro/go-config/source"
@@ -65,17 +63,14 @@ func (w *watcher) handle(oldCmp interface{}, newCmp interface{}) {
 		return
 	}
 
-	h := md5.New()
-	h.Write(b)
-	checksum := fmt.Sprintf("%x", h.Sum(nil))
-
-	w.ch <- &source.ChangeSet{
-		Format:   "json",
-		Source:   w.name,
-		Data:     b,
-		Checksum: checksum,
+	cs := &source.ChangeSet{
+		Format: "json",
+		Source: w.name,
+		Data:   b,
 	}
+	cs.Checksum = cs.Sum()
 
+	w.ch <- cs
 }
 
 // Next

--- a/source/configmap/watcher.go
+++ b/source/configmap/watcher.go
@@ -70,6 +70,7 @@ func (w *watcher) handle(oldCmp interface{}, newCmp interface{}) {
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 
 	w.ch <- &source.ChangeSet{
+		Format:   "json",
 		Source:   w.name,
 		Data:     b,
 		Checksum: checksum,

--- a/source/consul/consul.go
+++ b/source/consul/consul.go
@@ -1,10 +1,10 @@
 package consul
 
 import (
-	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/micro/go-config/source"
@@ -40,16 +40,15 @@ func (c *consul) Read() (*source.ChangeSet, error) {
 		return nil, fmt.Errorf("error reading source: %v", err)
 	}
 
-	// hash the consul
-	h := md5.New()
-	h.Write(b)
+	cs := &source.ChangeSet{
+		Timestamp: time.Now(),
+		Format:    "json",
+		Source:    c.String(),
+		Data:      b,
+	}
+	cs.Checksum = cs.Sum()
 
-	return &source.ChangeSet{
-		Format:   "json",
-		Source:   c.String(),
-		Data:     b,
-		Checksum: fmt.Sprintf("%x", h.Sum(nil)),
-	}, nil
+	return cs, nil
 }
 
 func (c *consul) String() string {

--- a/source/consul/consul.go
+++ b/source/consul/consul.go
@@ -45,6 +45,7 @@ func (c *consul) Read() (*source.ChangeSet, error) {
 	h.Write(b)
 
 	return &source.ChangeSet{
+		Format:   "json",
 		Source:   c.String(),
 		Data:     b,
 		Checksum: fmt.Sprintf("%x", h.Sum(nil)),

--- a/source/consul/watcher.go
+++ b/source/consul/watcher.go
@@ -1,10 +1,9 @@
 package consul
 
 import (
-	"crypto/md5"
 	"encoding/json"
 	"errors"
-	"fmt"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/watch"
@@ -60,16 +59,15 @@ func (w *watcher) handle(idx uint64, data interface{}) {
 		return
 	}
 
-	h := md5.New()
-	h.Write(b)
-	checksum := fmt.Sprintf("%x", h.Sum(nil))
-
-	w.ch <- &source.ChangeSet{
-		Format:   "json",
-		Source:   w.name,
-		Data:     b,
-		Checksum: checksum,
+	cs := &source.ChangeSet{
+		Timestamp: time.Now(),
+		Format:    "json",
+		Source:    w.name,
+		Data:      b,
 	}
+	cs.Checksum = cs.Sum()
+
+	w.ch <- cs
 }
 
 func (w *watcher) Next() (*source.ChangeSet, error) {

--- a/source/consul/watcher.go
+++ b/source/consul/watcher.go
@@ -65,6 +65,7 @@ func (w *watcher) handle(idx uint64, data interface{}) {
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 
 	w.ch <- &source.ChangeSet{
+		Format:   "json",
 		Source:   w.name,
 		Data:     b,
 		Checksum: checksum,

--- a/source/envvar/envvar.go
+++ b/source/envvar/envvar.go
@@ -74,6 +74,7 @@ func (e *envvar) Read() (*source.ChangeSet, error) {
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 
 	return &source.ChangeSet{
+		Format:    "json",
 		Data:      b,
 		Checksum:  checksum,
 		Timestamp: time.Now(),

--- a/source/envvar/envvar.go
+++ b/source/envvar/envvar.go
@@ -1,9 +1,7 @@
 package envvar
 
 import (
-	"crypto/md5"
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -69,17 +67,15 @@ func (e *envvar) Read() (*source.ChangeSet, error) {
 		return nil, err
 	}
 
-	h := md5.New()
-	h.Write(b)
-	checksum := fmt.Sprintf("%x", h.Sum(nil))
-
-	return &source.ChangeSet{
+	cs := &source.ChangeSet{
 		Format:    "json",
 		Data:      b,
-		Checksum:  checksum,
 		Timestamp: time.Now(),
 		Source:    e.String(),
-	}, nil
+	}
+	cs.Checksum = cs.Sum()
+
+	return cs, nil
 }
 
 func matchPrefix(pre []string, s string) (string, bool) {

--- a/source/file/file.go
+++ b/source/file/file.go
@@ -40,6 +40,7 @@ func (f *file) Read() (*source.ChangeSet, error) {
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 
 	return &source.ChangeSet{
+		Format:    format(f.path),
 		Source:    f.String(),
 		Timestamp: info.ModTime(),
 		Data:      b,

--- a/source/file/file.go
+++ b/source/file/file.go
@@ -2,8 +2,6 @@
 package file
 
 import (
-	"crypto/md5"
-	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -34,18 +32,15 @@ func (f *file) Read() (*source.ChangeSet, error) {
 		return nil, err
 	}
 
-	// hash the file
-	h := md5.New()
-	h.Write(b)
-	checksum := fmt.Sprintf("%x", h.Sum(nil))
-
-	return &source.ChangeSet{
+	cs := &source.ChangeSet{
 		Format:    format(f.path),
 		Source:    f.String(),
 		Timestamp: info.ModTime(),
 		Data:      b,
-		Checksum:  checksum,
-	}, nil
+	}
+	cs.Checksum = cs.Sum()
+
+	return cs, nil
 }
 
 func (f *file) String() string {

--- a/source/file/format.go
+++ b/source/file/format.go
@@ -1,0 +1,13 @@
+package file
+
+import (
+	"strings"
+)
+
+func format(p string) string {
+	parts := strings.Split(p, ".")
+	if len(parts) > 1 {
+		return parts[len(parts)-1]
+	}
+	return "json"
+}

--- a/source/file/format_test.go
+++ b/source/file/format_test.go
@@ -1,0 +1,26 @@
+package file
+
+import (
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	testCases := []struct {
+		p string
+		f string
+	}{
+		{"/foo/bar.json", "json"},
+		{"/foo/bar.yaml", "yaml"},
+		{"/foo/bar.xml", "xml"},
+		{"/foo/bar.conf.ini", "ini"},
+		{"conf", "json"},
+	}
+
+	for _, d := range testCases {
+		f := format(d.p)
+		if f != d.f {
+			t.Fatalf("%s: expected %s got %s", d.p, d.f, f)
+		}
+	}
+
+}

--- a/source/flag/flag.go
+++ b/source/flag/flag.go
@@ -1,11 +1,9 @@
 package flag
 
 import (
-	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"flag"
-	"fmt"
 	"github.com/imdario/mergo"
 	"github.com/micro/go-config/source"
 	"strings"
@@ -46,17 +44,15 @@ func (fs *flagsrc) Read() (*source.ChangeSet, error) {
 		return nil, err
 	}
 
-	h := md5.New()
-	h.Write(b)
-	checksum := fmt.Sprintf("%x", h.Sum(nil))
-
-	return &source.ChangeSet{
+	cs := &source.ChangeSet{
 		Format:    "json",
 		Data:      b,
-		Checksum:  checksum,
 		Timestamp: time.Now(),
 		Source:    fs.String(),
-	}, nil
+	}
+	cs.Checksum = cs.Sum()
+
+	return cs, nil
 }
 
 func reverse(ss []string) {

--- a/source/flag/flag.go
+++ b/source/flag/flag.go
@@ -51,6 +51,7 @@ func (fs *flagsrc) Read() (*source.ChangeSet, error) {
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 
 	return &source.ChangeSet{
+		Format:    "json",
 		Data:      b,
 		Checksum:  checksum,
 		Timestamp: time.Now(),

--- a/source/memory/README.md
+++ b/source/memory/README.md
@@ -27,7 +27,7 @@ Specify source with data
 
 ```go
 memorySource := memory.NewSource(
-	memory.WithData(data),
+	memory.WithData(data, "json"),
 )
 ```
 

--- a/source/memory/memory.go
+++ b/source/memory/memory.go
@@ -2,8 +2,6 @@
 package memory
 
 import (
-	"crypto/md5"
-	"fmt"
 	"sync"
 	"time"
 
@@ -50,19 +48,15 @@ func (s *memory) Update(c *source.ChangeSet) {
 	}
 
 	// hash the file
-	h := md5.New()
-	h.Write(c.Data)
-	checksum := fmt.Sprintf("%x", h.Sum(nil))
-
 	s.Lock()
 	// update changeset
 	s.ChangeSet = &source.ChangeSet{
-		Checksum:  checksum,
 		Data:      c.Data,
 		Format:    c.Format,
 		Source:    "memory",
 		Timestamp: time.Now(),
 	}
+	s.ChangeSet.Checksum = s.ChangeSet.Sum()
 
 	// update watchers
 	for _, w := range s.Watchers {

--- a/source/memory/memory.go
+++ b/source/memory/memory.go
@@ -43,19 +43,25 @@ func (s *memory) Watch() (source.Watcher, error) {
 }
 
 // Update allows manual updates of the config data.
-func (s *memory) Update(data []byte) {
+func (s *memory) Update(c *source.ChangeSet) {
+	// don't process nil
+	if c == nil {
+		return
+	}
+
 	// hash the file
 	h := md5.New()
-	h.Write(data)
+	h.Write(c.Data)
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 
 	s.Lock()
 	// update changeset
 	s.ChangeSet = &source.ChangeSet{
-		Timestamp: time.Now(),
-		Data:      data,
 		Checksum:  checksum,
+		Data:      c.Data,
+		Format:    c.Format,
 		Source:    "memory",
+		Timestamp: time.Now(),
 	}
 
 	// update watchers
@@ -78,18 +84,16 @@ func NewSource(opts ...source.Option) source.Source {
 		o(&options)
 	}
 
-	var data []byte
-
-	if options.Context != nil {
-		d, ok := options.Context.Value(dataKey{}).([]byte)
-		if ok {
-			data = d
-		}
-	}
-
 	s := &memory{
 		Watchers: make(map[string]*watcher),
 	}
-	s.Update(data)
+
+	if options.Context != nil {
+		c, ok := options.Context.Value(changeSetKey{}).(*source.ChangeSet)
+		if ok {
+			s.Update(c)
+		}
+	}
+
 	return s
 }

--- a/source/memory/options.go
+++ b/source/memory/options.go
@@ -19,14 +19,14 @@ func WithChangeSet(cs *source.ChangeSet) source.Option {
 }
 
 // WithData allows the source data to be set
-func WithData(d []byte, format string) source.Option {
+func WithData(d []byte) source.Option {
 	return func(o *source.Options) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
 		o.Context = context.WithValue(o.Context, changeSetKey{}, &source.ChangeSet{
 			Data:   d,
-			Format: format,
+			Format: "json",
 		})
 	}
 }

--- a/source/memory/options.go
+++ b/source/memory/options.go
@@ -1,19 +1,32 @@
 package memory
 
 import (
-	"github.com/micro/go-config/source"
-
 	"context"
+
+	"github.com/micro/go-config/source"
 )
 
-type dataKey struct{}
+type changeSetKey struct{}
 
-// WithData allows the source data to be set
-func WithData(d []byte) source.Option {
+// WithChangeSet allows a changeset to be set
+func WithChangeSet(cs *source.ChangeSet) source.Option {
 	return func(o *source.Options) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
-		o.Context = context.WithValue(o.Context, dataKey{}, d)
+		o.Context = context.WithValue(o.Context, changeSetKey{}, cs)
+	}
+}
+
+// WithData allows the source data to be set
+func WithData(d []byte, format string) source.Option {
+	return func(o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, changeSetKey{}, &source.ChangeSet{
+			Data:   d,
+			Format: format,
+		})
 	}
 }

--- a/source/microcli/cli.go
+++ b/source/microcli/cli.go
@@ -70,7 +70,7 @@ func reverse(ss []string) {
 }
 
 func split(r rune) bool {
-    return r == '-' || r == '_'
+	return r == '-' || r == '_'
 }
 
 func (c *clisrc) Watch() (source.Watcher, error) {

--- a/source/microcli/cli.go
+++ b/source/microcli/cli.go
@@ -1,9 +1,7 @@
 package microcli
 
 import (
-	"crypto/md5"
 	"encoding/json"
-	"fmt"
 	"github.com/imdario/mergo"
 	"github.com/micro/cli"
 	"github.com/micro/go-config/source"
@@ -34,17 +32,15 @@ func (c *clisrc) Read() (*source.ChangeSet, error) {
 		return nil, err
 	}
 
-	h := md5.New()
-	h.Write(b)
-	checksum := fmt.Sprintf("%x", h.Sum(nil))
-
-	return &source.ChangeSet{
+	cs := &source.ChangeSet{
 		Format:    "json",
 		Data:      b,
-		Checksum:  checksum,
 		Timestamp: time.Now(),
 		Source:    c.String(),
-	}, nil
+	}
+	cs.Checksum = cs.Sum()
+
+	return cs, nil
 }
 
 func toEntry(name string, v interface{}) map[string]interface{} {

--- a/source/microcli/cli.go
+++ b/source/microcli/cli.go
@@ -39,6 +39,7 @@ func (c *clisrc) Read() (*source.ChangeSet, error) {
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 
 	return &source.ChangeSet{
+		Format:    "json",
 		Data:      b,
 		Checksum:  checksum,
 		Timestamp: time.Now(),

--- a/source/source.go
+++ b/source/source.go
@@ -17,8 +17,9 @@ type Source interface {
 type ChangeSet struct {
 	Data      []byte
 	Checksum  string
-	Timestamp time.Time
+	Format    string
 	Source    string
+	Timestamp time.Time
 }
 
 // Watcher watches a source for changes


### PR DESCRIPTION
Adds Format field to ChangeSet. Just a first step towards parsing different types of config formats.

We need to treat Source as an abstraction that still returns Data as bytes but gives an indicator of Format. Initially everything is json but we may support a Parser/Reader/Formatter that can deal with other formats.

This is separate to the step beyond in merging different source ChangeSets. That will require additional changes to allow merging multiple formats. Likely by turning a ChangeSet into map[string]interface{} or proving an JSON() method.