### PR TITLE
Add scan and map to reader

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,16 +10,14 @@ import (
 
 // Config is an interface abstraction for dynamic configuration
 type Config interface {
+	// provide the reader.Values interface
+	reader.Values
 	// Stop the config loader/watcher
 	Close() error
-	// Get the whole config as raw output
-	Bytes() []byte
-	// Force a source changeset sync
-	Sync() error
-	// Get a value from the config
-	Get(path ...string) reader.Value
 	// Load config sources
 	Load(source ...source.Source) error
+	// Force a source changeset sync
+	Sync() error
 	// Watch a value for changes
 	Watch(path ...string) (Watcher, error)
 }
@@ -53,6 +51,16 @@ func NewConfig(opts ...Option) Config {
 // Return config as raw json
 func Bytes() []byte {
 	return DefaultConfig.Bytes()
+}
+
+// Return config as a map
+func Map() map[string]interface{} {
+	return DefaultConfig.Map()
+}
+
+// Scan values to a go type
+func Scan(v interface{}) error {
+	return DefaultConfig.Scan(v)
 }
 
 // Force a source changeset sync

--- a/default.go
+++ b/default.go
@@ -162,6 +162,18 @@ func (c *config) update() {
 	}
 }
 
+func (c *config) Map() map[string]interface{} {
+	c.RLock()
+	defer c.RUnlock()
+	return c.vals.Map()
+}
+
+func (c *config) Scan(v interface{}) error {
+	c.RLock()
+	defer c.RUnlock()
+	return c.vals.Scan(v)
+}
+
 // sync loads all the sources, calls the parser and updates the config
 func (c *config) Sync() error {
 	var sets []*source.ChangeSet
@@ -353,6 +365,10 @@ func (c *config) Watch(path ...string) (Watcher, error) {
 	}()
 
 	return w, nil
+}
+
+func (c *config) String() string {
+	return "config"
 }
 
 func (w *watcher) Next() (reader.Value, error) {

--- a/reader/json/values.go
+++ b/reader/json/values.go
@@ -72,6 +72,14 @@ func (j *jsonValues) Map() map[string]interface{} {
 	return m
 }
 
+func (j *jsonValues) Scan(v interface{}) error {
+	b, err := j.sj.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+
 func (j *jsonValues) String() string {
 	return "json"
 }

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -19,7 +19,7 @@ type Values interface {
 	Bytes() []byte
 	Get(path ...string) Value
 	Map() map[string]interface{}
-	String() string
+	Scan(v interface{}) error
 }
 
 // Value represents a value of any type


### PR DESCRIPTION
This adds `Scan` and `Map` methods to `reader.Values` so that the entire config can easily be retrieved.