### PR TITLE
fix watch data get null

### DIFF
--- a/default.go
+++ b/default.go
@@ -242,7 +242,8 @@ func (w *watcher) Next() (reader.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		w.value = v.Get(w.path...)
+
+		w.value = v.Get()
 		return w.value, nil
 	}
 }


### PR DESCRIPTION
func (w *watcher) Next() (reader.Value, error) {
	for {
		s, err := w.lw.Next()
		if err != nil {
			return nil, err
		}

		// only process changes
		if bytes.Equal(w.value.Bytes(), s.ChangeSet.Data) {
			continue
		}

		v, err := w.rd.Values(s.ChangeSet)
		if err != nil {
			return nil, err
		}

                 // w.value = v.Get(w.path...)    v is your ChangeSet,you should not call Get(w.path..)

		w.value = v.Get()
		return w.value, nil
	}
}
