### PR TITLE
feat(consul): add create if not exist prefix possibility

### DIFF
--- a/source/consul/consul.go
+++ b/source/consul/consul.go
@@ -98,6 +98,14 @@ func NewSource(opts ...source.Option) source.Source {
 		sp = prefix
 	}
 
+	if b, ok := options.Context.Value(createPrefixIfNotExist{}).(bool); ok && b {
+		kv := client.KV()
+		pair, _, _ := kv.Get(prefix, nil)
+		if pair == nil {
+			kv.Put(&api.KVPair{Key: prefix}, nil)
+		}
+	}
+
 	return &consul{
 		prefix:      prefix,
 		stripPrefix: sp,

--- a/source/consul/options.go
+++ b/source/consul/options.go
@@ -9,6 +9,7 @@ import (
 type addressKey struct{}
 type prefixKey struct{}
 type stripPrefixKey struct{}
+type createPrefixIfNotExist struct {}
 
 // WithAddress sets the consul address
 func WithAddress(a string) source.Option {
@@ -38,5 +39,16 @@ func StripPrefix(strip bool) source.Option {
 		}
 
 		o.Context = context.WithValue(o.Context, stripPrefixKey{}, strip)
+	}
+}
+
+// Create consul prefix if not exist
+func CreatePrefixIfNotExist(create bool) source.Option {
+	return func (o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+
+		o.Context = context.WithValue(o.Context, createPrefixIfNotExist{}, create)
 	}
 }


### PR DESCRIPTION
I want to have possibility use Consul source with empty prefix value. When I first time deploying my service I must create a prefix. In my pull request, you can use option createPrefixIfNotExist and if you don't have a prefix in consul will be created.