### PR TITLE
 Add IncludeUnset option to flag source

### DIFF
--- a/source/flag/README.md
+++ b/source/flag/README.md
@@ -27,7 +27,11 @@ Becomes
 ## New Source
 
 ```go
-flagSource := flag.NewSource()
+flagSource := flag.NewSource(
+	// optionally enable reading of unset flags and their default
+  // values into config, defaults to false
+  IncludeUnset(true)
+)
 ```
 
 ## Load Source

--- a/source/flag/README.md
+++ b/source/flag/README.md
@@ -29,8 +29,8 @@ Becomes
 ```go
 flagSource := flag.NewSource(
 	// optionally enable reading of unset flags and their default
-  // values into config, defaults to false
-  IncludeUnset(true)
+	// values into config, defaults to false
+	IncludeUnset(true)
 )
 ```
 

--- a/source/flag/flag_test.go
+++ b/source/flag/flag_test.go
@@ -6,14 +6,19 @@ import (
 	"testing"
 )
 
-func TestFlagsrc_Read(t *testing.T) {
-	dbhost := flag.String("database-host", "", "db host")
-	dbpw := flag.String("database-password", "", "db pw")
+var (
+	dbuser = flag.String("database-user", "default", "db user")
+	dbhost = flag.String("database-host", "", "db host")
+	dbpw   = flag.String("database-password", "", "db pw")
+)
 
+func init() {
 	flag.Set("database-host", "localhost")
 	flag.Set("database-password", "some-password")
 	flag.Parse()
+}
 
+func TestFlagsrc_Read(t *testing.T) {
 	source := NewSource()
 	c, err := source.Read()
 	if err != nil {
@@ -32,5 +37,30 @@ func TestFlagsrc_Read(t *testing.T) {
 
 	if actualDB["password"] != *dbpw {
 		t.Errorf("expected %v got %v", *dbpw, actualDB["password"])
+	}
+
+	// unset flags should not be loaded
+	if actualDB["user"] != nil {
+		t.Errorf("expected %v got %v", nil, actualDB["user"])
+	}
+}
+
+func TestFlagsrc_ReadAll(t *testing.T) {
+	source := NewSource(IncludeUnset(true))
+	c, err := source.Read()
+	if err != nil {
+		t.Error(err)
+	}
+
+	var actual map[string]interface{}
+	if err := json.Unmarshal(c.Data, &actual); err != nil {
+		t.Error(err)
+	}
+
+	actualDB := actual["database"].(map[string]interface{})
+
+	// unset flag defaults should be loaded
+	if actualDB["user"] != *dbuser {
+		t.Errorf("expected %v got %v", *dbuser, actualDB["user"])
 	}
 }

--- a/source/flag/options.go
+++ b/source/flag/options.go
@@ -1,0 +1,20 @@
+package flag
+
+import (
+	"context"
+
+	"github.com/micro/go-config/source"
+)
+
+type includeUnsetKey struct{}
+
+// IncludeUnset toggles the loading of unset flags and their respective default values.
+// Default behavior is to ignore any unset flags.
+func IncludeUnset(b bool) source.Option {
+	return func(o *source.Options) {
+		if o.Context == nil {
+			o.Context = context.Background()
+		}
+		o.Context = context.WithValue(o.Context, includeUnsetKey{}, true)
+	}
+}


### PR DESCRIPTION
Current default behavior ignores any flags and flag defaults if not explicitly set.

`IncludeUnset` option enables reading of all set+unset flags, along with their default values, if not explicitly set by the user.