### PR TITLE
Fix #62

### DIFF
--- a/source/consul/consul.go
+++ b/source/consul/consul.go
@@ -65,6 +65,7 @@ func (c *consul) Watch() (source.Watcher, error) {
 	return w, nil
 }
 
+// NewSource creates a new consul source
 func NewSource(opts ...source.Option) source.Source {
 	options := source.NewOptions(opts...)
 

--- a/source/consul/consul.go
+++ b/source/consul/consul.go
@@ -19,6 +19,8 @@ type consul struct {
 }
 
 var (
+	// DefaultPrefix is the prefix that consul keys will be assumed to have if you
+	// haven't specified one
 	DefaultPrefix = "/micro/config/"
 )
 

--- a/source/consul/util.go
+++ b/source/consul/util.go
@@ -11,7 +11,7 @@ import (
 func makeMap(e encoder.Encoder, kv api.KVPairs, stripPrefix string) (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 
-	// consul guarantees lexographic order, so no need to sort
+	// consul guarantees lexicographic order, so no need to sort
 	for _, v := range kv {
 		pathString := strings.TrimPrefix(strings.TrimPrefix(v.Key, stripPrefix), "/")
 		var val map[string]interface{}


### PR DESCRIPTION
This is an updated version of `makeMap` that correctly handles first-level key merging, and doesn't require calls like `config.Get("", "test").String("default")`

Fixes #62 