### PR TITLE
update import paths for Go Cloud runtimevar

### DIFF
--- a/source/runtimevar/README.md
+++ b/source/runtimevar/README.md
@@ -2,9 +2,9 @@
 
 The runtimevar source is a source for the [Go Cloud](https://github.com/google/go-cloud) runtimevar package
 
-This package takes a [driver.Watcher](https://godoc.org/github.com/google/go-cloud/runtimevar/driver#Watcher) 
-and then allows you to use it as a backend source. We expect the 
-[Snapshot](https://godoc.org/github.com/google/go-cloud/runtimevar#Snapshot) value to be `[]byte`. 
+This package takes a [driver.Watcher](https://godoc.org/gocloud.dev/runtimevar/driver#Watcher)
+and then allows you to use it as a backend source. We expect the
+[Snapshot](https://godoc.org/gocloud.dev/runtimevar#Snapshot) value to be `[]byte`.
 We use the built in encoder to decode the value. This defaults to json.
 
 ## Example

--- a/source/runtimevar/options.go
+++ b/source/runtimevar/options.go
@@ -3,8 +3,8 @@ package runtimevar
 import (
 	"context"
 
-	"github.com/google/go-cloud/runtimevar/driver"
 	"github.com/micro/go-config/source"
+	"gocloud.dev/runtimevar/driver"
 )
 
 type driverWatcherKey struct{}

--- a/source/runtimevar/runtimevar.go
+++ b/source/runtimevar/runtimevar.go
@@ -1,4 +1,4 @@
-// package runtimevar is the source for github.com/google/go-cloud/runtimevar
+// package runtimevar is the source for gocloud.dev/runtimevar
 package runtimevar
 
 import (

--- a/source/runtimevar/runtimevar.go
+++ b/source/runtimevar/runtimevar.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/go-cloud/runtimevar"
-	"github.com/google/go-cloud/runtimevar/driver"
 	"github.com/micro/go-config/source"
+	"gocloud.dev/runtimevar"
+	"gocloud.dev/runtimevar/driver"
 )
 
 type rvSource struct {

--- a/source/runtimevar/watcher.go
+++ b/source/runtimevar/watcher.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/go-cloud/runtimevar"
-	"github.com/google/go-cloud/runtimevar/driver"
 	"github.com/micro/go-config/source"
+	"gocloud.dev/runtimevar"
+	"gocloud.dev/runtimevar/driver"
 )
 
 type watcher struct {


### PR DESCRIPTION
We've updated our import paths to "gocloud.dev".