### PR TITLE
Expose Go Cloud's runtimevar using runtimevar.Variable, not driver.Watcher

### DIFF
--- a/source/runtimevar/README.md
+++ b/source/runtimevar/README.md
@@ -1,50 +1,34 @@
 # Runtimevar Source
 
-The runtimevar source is a source for the [Go Cloud](https://github.com/google/go-cloud) runtimevar package
+The runtimevar source is a source for the [Go Cloud](https://github.com/google/go-cloud) runtimevar package.
 
-This package takes a [driver.Watcher](https://godoc.org/gocloud.dev/runtimevar/driver#Watcher)
-and then allows you to use it as a backend source. We expect the
-[Snapshot](https://godoc.org/gocloud.dev/runtimevar#Snapshot) value to be `[]byte`.
-We use the built in encoder to decode the value. This defaults to json.
-
-## Example
-
-A runtimevar config format in json
-
-```json
-{
-    "hosts": {
-        "database": {
-            "address": "10.0.0.1",
-            "port": 3306
-        },
-        "cache": {
-            "address": "10.0.0.2",
-            "port": 6379
-        }
-    }
-}
-```
+This package takes a [runtimevar.Variable](https://godoc.org/gocloud.dev/runtimevar/#Variable)
+and then allows you to use it as a backend source. When constructing your
+`runtimevar.Variable`, use the `gocloud.dev/runtimevar.BytesDecoder` decoder to
+allow your [Snapshot](https://godoc.org/gocloud.dev/runtimevar#Snapshot) value
+to be `[]byte`. We then use the built in go-config encoder to decode the value. This defaults to json.
 
 ## New Source
 
-Specify runtimevar source with watcher. It will panic if not specified.
+Specify a runtimevar source with the Go Cloud runtimevar.Variable. It will panic if not specified.
 
 ```go
+// See https://godoc.org/gocloud.dev/runtimevar for examples on how to create
+// a gocloud.dev/runtimevar.Varible. Use a BytesDecoder.
 srv := runtimevar.NewSource(
-	runtimevar.WithDriver(dv),
+	runtimevar.WithVariable(v),
 )
 ```
 
 ## Config Format
 
-To load different runtimevar formats e.g yaml, toml, xml you must specify an encoder
+To load different runtimevar formats e.g yaml, toml, xml you must specify an encoder.
 
 ```
 e := toml.NewEncoder()
 
 src := runtimevar.NewSource(
-        runtimevar.WithDriver(dv),
+        runtimevar.WithVariable(v),
 	source.WithEncoder(e),
 )
 ```

--- a/source/runtimevar/options.go
+++ b/source/runtimevar/options.go
@@ -4,17 +4,17 @@ import (
 	"context"
 
 	"github.com/micro/go-config/source"
-	"gocloud.dev/runtimevar/driver"
+	"gocloud.dev/runtimevar"
 )
 
-type driverWatcherKey struct{}
+type variableKey struct{}
 
-// WithWatcher sets the runtimevar driver.Watcher
-func WithWatcher(dv driver.Watcher) source.Option {
+// WithVariable sets the runtimevar.Variable.
+func WithVariable(v *runtimevar.Variable) source.Option {
 	return func(o *source.Options) {
 		if o.Context == nil {
 			o.Context = context.Background()
 		}
-		o.Context = context.WithValue(o.Context, driverWatcherKey{}, dv)
+		o.Context = context.WithValue(o.Context, variableKey{}, v)
 	}
 }

--- a/source/runtimevar/runtimevar.go
+++ b/source/runtimevar/runtimevar.go
@@ -8,15 +8,13 @@ import (
 
 	"github.com/micro/go-config/source"
 	"gocloud.dev/runtimevar"
-	"gocloud.dev/runtimevar/driver"
 )
 
 type rvSource struct {
 	opts source.Options
 
 	sync.Mutex
-	v  *runtimevar.Variable
-	dv driver.Watcher
+	v *runtimevar.Variable
 }
 
 func (rv *rvSource) Read() (*source.ChangeSet, error) {
@@ -43,7 +41,7 @@ func (rv *rvSource) Read() (*source.ChangeSet, error) {
 }
 
 func (rv *rvSource) Watch() (source.Watcher, error) {
-	return newWatcher(rv.String(), rv.dv, rv.opts)
+	return newWatcher(rv.String(), rv.v, rv.opts)
 }
 
 func (rv *rvSource) String() string {
@@ -53,14 +51,14 @@ func (rv *rvSource) String() string {
 func NewSource(opts ...source.Option) source.Source {
 	options := source.NewOptions(opts...)
 
-	dv, ok := options.Context.Value(driverWatcherKey{}).(driver.Watcher)
+	v, ok := options.Context.Value(variableKey{}).(*runtimevar.Variable)
 	if !ok {
 		// nooooooo
-		panic("driver watcher required")
+		panic("runtimevar.Variable required")
 	}
 
 	return &rvSource{
 		opts: options,
-		v:    runtimevar.New(dv),
+		v:    v,
 	}
 }

--- a/source/runtimevar/watcher.go
+++ b/source/runtimevar/watcher.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/micro/go-config/source"
 	"gocloud.dev/runtimevar"
-	"gocloud.dev/runtimevar/driver"
 )
 
 type watcher struct {
@@ -69,11 +68,11 @@ func (w *watcher) Stop() error {
 	}
 }
 
-func newWatcher(name string, dv driver.Watcher, opts source.Options) (source.Watcher, error) {
+func newWatcher(name string, v *runtimevar.Variable, opts source.Options) (source.Watcher, error) {
 	return &watcher{
 		name: name,
 		opts: opts,
 		exit: make(chan bool),
-		v:    runtimevar.New(dv),
+		v:    v,
 	}, nil
 }


### PR DESCRIPTION
Fixes #65.