### PR TITLE
fix fsnotify may stops watching file when modified using vim

### DIFF
--- a/source/file/watcher.go
+++ b/source/file/watcher.go
@@ -41,12 +41,6 @@ func (w *watcher) Next() (*source.ChangeSet, error) {
 	// try get the event
 	select {
 	case event, _ := <-w.fw.Events:
-		/*
-			when 'backupcopy' option of vim is "no".
-			vim will rename the file and write a new one,
-			fsnotify stops watching the the named file,
-			should add watch again if the file exists
-		*/
 		if event.Op == fsnotify.Rename {
 			// check existence of file, and add watch again
 			_, err := os.Stat(event.Name)

--- a/source/file/watcher.go
+++ b/source/file/watcher.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"errors"
+	"os"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/micro/go-config/source"
@@ -39,7 +40,21 @@ func (w *watcher) Next() (*source.ChangeSet, error) {
 
 	// try get the event
 	select {
-	case <-w.fw.Events:
+	case event, _ := <-w.fw.Events:
+		/*
+			when 'backupcopy' option of vim is "no".
+			vim will rename the file and write a new one,
+			fsnotify stops watching the the named file,
+			should add watch again if the file exists
+		*/
+		if event.Op == fsnotify.Rename {
+			// check existence of file, and add watch again
+			_, err := os.Stat(event.Name)
+			if err == nil || os.IsExist(err) {
+				w.fw.Add(event.Name)
+			}
+		}
+
 		c, err := w.f.Read()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
when 'backupcopy' option of vim is "no". vim will rename the file and write a new one, fsnotify stops watching the the named file, should add watch again if the file exists

> This is discussed briefly in the [Writing](http://vimhelp.appspot.com/editing.txt.html#writing) section of the Vim documentation, with further information in the [`'backupcopy'`](http://vimhelp.appspot.com/options.txt.html#%27backupcopy%27) option documentation.