### PR TITLE
API of the micro framework has changed.

### DIFF
--- a/source/microcli/README.md
+++ b/source/microcli/README.md
@@ -57,7 +57,9 @@ func main() {
 
     service.Init(
         micro.Action(func(c *cli.Context) {
-            clisrc = microcli.NewSource(c)
+            clisrc = microcli.NewSource(
+				microcli.Context(c),
+			)
             // Alternatively, just setup your config right here
         }),
     )

--- a/source/microcli/README.md
+++ b/source/microcli/README.md
@@ -59,7 +59,7 @@ func main() {
         micro.Action(func(c *cli.Context) {
             clisrc = microcli.NewSource(
 				microcli.Context(c),
-			)
+	    )
             // Alternatively, just setup your config right here
         }),
     )

--- a/source/microcli/README.md
+++ b/source/microcli/README.md
@@ -9,7 +9,7 @@ We expect the use of the `micro/cli` package. Upper case flags will be lower cas
 ### Example
 
 ```go
-micro.Flags([]cli.Flag{
+micro.Flags(
     cli.StringFlag{
         Name: "database-address",
         Value: "127.0.0.1",
@@ -20,7 +20,7 @@ micro.Flags([]cli.Flag{
         Value: 3306,
         Usage: "the db port",
     },
-})
+)
 ```
 
 Becomes
@@ -44,13 +44,13 @@ func main() {
     // New Service
     service := micro.NewService(
         micro.Name("example"),
-        micro.Flags([]cli.Flag{
+        micro.Flags(
             cli.StringFlag{
                 Name: "database-address",
                 Value: "127.0.0.1",
                 Usage: "the db address",
             },
-        }),
+        ),
     )
 
     var clisrc source.Source

--- a/source/microcli/README.md
+++ b/source/microcli/README.md
@@ -58,7 +58,7 @@ func main() {
     service.Init(
         micro.Action(func(c *cli.Context) {
             clisrc = microcli.NewSource(
-				microcli.Context(c),
+                microcli.Context(c),
 	    )
             // Alternatively, just setup your config right here
         }),


### PR DESCRIPTION
Code remain like that should cause error as following:
```
# command-line-arguments
token-service/main.go:26:25: cannot use []cli.Flag literal (type []cli.Flag) as type cli.Flag in argument to micro.Flags:
	[]cli.Flag does not implement cli.Flag (missing Apply method)
```