### PR TITLE
Correclty handle integer values in env variables

### DIFF
--- a/source/env/env.go
+++ b/source/env/env.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"time"
 

--- a/source/env/env.go
+++ b/source/env/env.go
@@ -49,7 +49,13 @@ func (e *env) Read() (*source.ChangeSet, error) {
 		tmp := make(map[string]interface{})
 		for i, k := range keys {
 			if i == 0 {
-				tmp[k] = value
+				if intValue, err := strconv.Atoi(value); err == nil {
+					tmp[k] = intValue
+				} else if boolValue, err := strconv.ParseBool(value); err == nil {
+					tmp[k] = boolValue
+				} else {
+					tmp[k] = value
+				}
 				continue
 			}
 


### PR DESCRIPTION
The code handles integer and boolean values always as strings. When calling Scan to populate a golang structure containing integers, the json marshaller fails because it cannot map a string to an integer.