### PR TITLE
using configmaps instead of configmap since k8s only have configmaps …

### DIFF
--- a/source/configmap/watcher.go
+++ b/source/configmap/watcher.go
@@ -35,7 +35,7 @@ func newWatcher(n, ns string, c *kubernetes.Clientset, opts source.Options) (sou
 		stop:      make(chan struct{}),
 	}
 
-	lw := cache.NewListWatchFromClient(w.client.CoreV1().RESTClient(), "ConfigMap", w.namespace, fields.OneTermEqualSelector("metadata.name", w.name))
+	lw := cache.NewListWatchFromClient(w.client.CoreV1().RESTClient(), "ConfigMaps", w.namespace, fields.OneTermEqualSelector("metadata.name", w.name))
 	st, ct := cache.NewInformer(
 		lw,
 		&v12.ConfigMap{},


### PR DESCRIPTION
using configmaps instead of configmap since k8s only have configmaps 
below is current error:
E0321 23:52:56.750478       1 reflector.go:126] github.com/micro/go-config/source/configmap/watcher.go:48: Failed to list *v1.ConfigMap: the server could not find the requested resource
