### PR TITLE
Fix Snapshot RLock after Sync in memory loader

### DIFF
--- a/loader/memory/memory.go
+++ b/loader/memory/memory.go
@@ -184,7 +184,7 @@ func (m *memory) Snapshot() (*loader.Snapshot, error) {
 	}
 
 	// make copy
-	m.RUnlock()
+	m.RLock()
 	snap := loader.Copy(m.snap)
 	m.RUnlock()
 


### PR DESCRIPTION
It doesn't appear any locks would occur prior to copying the snapshot that would released with this unlock. I assume this is a typo given the pattern in the if block above.